### PR TITLE
fix code macro

### DIFF
--- a/man/make_with_beep.Rd
+++ b/man/make_with_beep.Rd
@@ -25,7 +25,7 @@ nothing
 Add a sound effect to alert the user when a \code{drake} plan has either completed or returned an error.
 }
 \note{
-\code{lock_envir = FALSE} is necessary if \codde{make_with_beep()} is used on a packaged \code{plan}
+\code{lock_envir = FALSE} is necessary if \code{make_with_beep()} is used on a packaged \code{plan}
 because \code{\link[drake]{expose_imports}()} needs to be run prior to making the plan
 (see the \code{drake} manual for details: \url{https://ropenscilabs.github.io/drake-manual/best-practices.html#workflows-as-r-packages})
 }


### PR DESCRIPTION
There is a single typo ("\codde" vs "\code") in the man/make_with_beep.Rd file. It throws a warning when installing locally, but the warning is converted to an error when using `devtools::install_github()`, which causes the installation to fail.

Should be working now.